### PR TITLE
Add htpasswd support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,5 @@ jobs:
         registry: dkr.plural.sh
         username: mjg@plural.sh
         password: ${{ secrets.PLURAL_ACCESS_TOKEN }}
-    - run: docker build -t dkr.plural.sh/bootstrap/plural-operator:v0.3.1 .
-    - run: docker push dkr.plural.sh/bootstrap/plural-operator:v0.3.1
+    - run: docker build -t dkr.plural.sh/bootstrap/plural-operator:v0.3.2 .
+    - run: docker push dkr.plural.sh/bootstrap/plural-operator:v0.3.2


### PR DESCRIPTION
Oauth Proxy supports adding a list of users in a htpasswd file that can be authenticated via basic auth.  This can help bypass some of the clunkiness of oauth for apps like airbyte and mlflow which have apis people might want to access via python.