### PR TITLE
ENG-110 force redeployment on basic auth user updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY alertmanager/ alertmanager/
 COPY resources/ resources/
+COPY services/ services/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM gcr.io/pluralsh/golang:1.15 as builder
 
+ARG TARGETARCH
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -17,7 +19,7 @@ COPY alertmanager/ alertmanager/
 COPY resources/ resources/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ test: manifests generate fmt vet ## Run tests.
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
+unit-test:
+	go test -tags=unit -v -race ./controllers/...
+
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.

--- a/api/security/v1alpha1/hooks/oauthinjector_webhook.go
+++ b/api/security/v1alpha1/hooks/oauthinjector_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"
+	"github.com/pluralsh/plural-operator/services/redeployment"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -59,6 +60,11 @@ func (oi *OAuthInjector) Handle(ctx context.Context, req admission.Request) admi
 	}
 
 	log.Info("Injecting sidecar...")
+
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Labels[redeployment.RedeployLabel] = "true"
 
 	secretRef := &[]corev1.EnvFromSource{
 		{

--- a/api/security/v1alpha1/hooks/oauthinjector_webhook.go
+++ b/api/security/v1alpha1/hooks/oauthinjector_webhook.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"

--- a/controllers/redeploy_configmap_controller.go
+++ b/controllers/redeploy_configmap_controller.go
@@ -1,0 +1,74 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/pluralsh/plural-operator/services/redeployment"
+)
+
+type ConfigMapRedeployReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Log    logr.Logger
+}
+
+func (c *ConfigMapRedeployReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := c.Log.WithValues("reconcile", req.NamespacedName)
+
+	configMap := &corev1.ConfigMap{}
+	err := c.Client.Get(ctx, req.NamespacedName, configMap)
+	if errors.IsNotFound(err) {
+		log.Error(nil, "could not find configmap")
+		return reconcile.Result{}, nil
+	}
+
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not fetch ConfigMap: %+v", err)
+	}
+
+	svc, err := redeployment.NewService(redeployment.ResourceConfigMap, c.Client, configMap)
+	if err != nil {
+		log.Error(nil, "could not create ConfigMap service")
+		return reconcile.Result{}, err
+	}
+
+	if !svc.IsControlled() {
+		return reconcile.Result{}, nil
+	}
+
+	if !svc.HasAnnotation() {
+		log.Info("updating config map with new sha")
+		return reconcile.Result{}, svc.UpdateAnnotation()
+	}
+
+	if svc.ShouldDeletePods() {
+		log.Info("deleting Pods")
+		err = svc.DeletePods()
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not delete pods: %w", err)
+		}
+
+		err = svc.UpdateAnnotation()
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update annotation: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *ConfigMapRedeployReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		Complete(c)
+}

--- a/controllers/redeploy_configmap_controller.go
+++ b/controllers/redeploy_configmap_controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/controllers/redeploy_configmap_controller_test.go
+++ b/controllers/redeploy_configmap_controller_test.go
@@ -46,15 +46,14 @@ func init() {
 
 func TestReconcileConfigMap(t *testing.T) {
 	tests := []struct {
-		name                  string
-		secretName            string
-		secretNamespace       string
-		expectedPods          []string
-		existingObjects       []ctrlruntimeclient.Object
-		expectedSHAAnnotation bool
+		name            string
+		secretName      string
+		secretNamespace string
+		expectedPods    []string
+		existingObjects []ctrlruntimeclient.Object
 	}{
 		{
-			name:            "scenario 1: no matching pods, don't add SHA annotation",
+			name:            "scenario 1: no matching pods",
 			secretNamespace: "test",
 			secretName:      "testconfig",
 			existingObjects: []ctrlruntimeclient.Object{
@@ -137,10 +136,8 @@ func TestReconcileConfigMap(t *testing.T) {
 			err = fakeClient.Get(ctx, client.ObjectKey{Name: test.secretName, Namespace: test.secretNamespace}, config)
 			assert.NoError(t, err)
 
-			if test.expectedSHAAnnotation {
-				_, shaAnnotation := config.Annotations[redeployment.ShaAnnotation]
-				assert.True(t, shaAnnotation, "expected SHA annotation")
-			}
+			_, shaAnnotation := config.Annotations[redeployment.ShaAnnotation]
+			assert.True(t, shaAnnotation, "expected SHA annotation")
 
 			existingPods := &corev1.PodList{}
 			labelSelector, err := redeployment.RedeployLabelSelector()

--- a/controllers/redeploy_configmap_controller_test.go
+++ b/controllers/redeploy_configmap_controller_test.go
@@ -1,3 +1,22 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/controllers/redeploy_configmap_controller_test.go
+++ b/controllers/redeploy_configmap_controller_test.go
@@ -1,0 +1,189 @@
+package controllers
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/pluralsh/plural-operator/api/platform/v1alpha1"
+	"github.com/pluralsh/plural-operator/services/redeployment"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+}
+
+func TestReconcileConfigMap(t *testing.T) {
+	tests := []struct {
+		name                  string
+		secretName            string
+		secretNamespace       string
+		expectedPods          []string
+		existingObjects       []ctrlruntimeclient.Object
+		expectedSHAAnnotation bool
+	}{
+		{
+			name:            "scenario 1: no matching pods, don't add SHA annotation",
+			secretNamespace: "test",
+			secretName:      "testconfig",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testconfig",
+						Namespace: "test",
+					},
+					Data: map[string]string{"z": "a", "a": "z"},
+				},
+				genPodWithConfigMapVolume("pod1", "test", "someconfig"),
+			},
+			expectedPods: []string{"pod1"},
+		},
+		{
+			name:            "scenario 2: two matching pods, delete those pods",
+			secretNamespace: "test",
+			secretName:      "testconfig",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testconfig",
+						Namespace:   "test",
+						Annotations: map[string]string{redeployment.ShaAnnotation: "xyz"},
+					},
+					Data: map[string]string{"z": "a", "a": "z"},
+				},
+				genPodWithConfigMapVolume("pod1", "test", "someconfig"),
+				genPodWithConfigMapVolume("pod2", "test", "testconfig"),
+				genPodWithConfigMapVolume("pod3", "test", "someconfig"),
+				genPodWithConfigMapVolume("pod4", "test", "testconfig"),
+			},
+			expectedPods: []string{"pod1", "pod3"},
+		},
+		{
+			name:            "scenario 3: delete pods with config reference and volumes",
+			secretNamespace: "test",
+			secretName:      "testconfig",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testconfig",
+						Namespace:   "test",
+						Annotations: map[string]string{redeployment.ShaAnnotation: "xyz"},
+					},
+					Data: map[string]string{"z": "a", "a": "z"},
+				},
+				genPodWithConfigMapVolume("pod1", "test", "someconfig"),
+				genPodWithConfigMapVolume("pod2", "test", "testconfig"),
+				genPodWithConfigMapVolume("pod3", "test", "someconfig"),
+				genPodWithConfigMapVolume("pod4", "test", "testconfig"),
+				genPodWithConfigRef("pod5", "test", "testconfig"),
+				genPodWithConfigRef("pod6", "test", "someconfig"),
+			},
+			expectedPods: []string{"pod1", "pod3", "pod6"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			fakeClient := fake.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(test.existingObjects...).
+				Build()
+
+			// act
+			ctx := context.Background()
+			target := ConfigMapRedeployReconciler{
+				Client: fakeClient,
+				Log:    ctrl.Log.WithName("controllers").WithName("RedeploySecretsController"),
+				Scheme: scheme.Scheme,
+			}
+
+			_, err := target.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: test.secretName, Namespace: test.secretNamespace}})
+			assert.NoError(t, err)
+
+			config := &corev1.ConfigMap{}
+			err = fakeClient.Get(ctx, client.ObjectKey{Name: test.secretName, Namespace: test.secretNamespace}, config)
+			assert.NoError(t, err)
+
+			if test.expectedSHAAnnotation {
+				_, shaAnnotation := config.Annotations[redeployment.ShaAnnotation]
+				assert.True(t, shaAnnotation, "expected SHA annotation")
+			}
+
+			existingPods := &corev1.PodList{}
+			labelSelector, err := redeployment.RedeployLabelSelector()
+			assert.NoError(t, err)
+			err = fakeClient.List(ctx, existingPods, &client.ListOptions{Namespace: test.secretNamespace, LabelSelector: labelSelector})
+			assert.NoError(t, err)
+			existingPodNames := []string{}
+			for _, pod := range existingPods.Items {
+				existingPodNames = append(existingPodNames, pod.Name)
+			}
+			sort.Strings(existingPodNames)
+			sort.Strings(test.expectedPods)
+
+			assert.Equal(t, existingPodNames, test.expectedPods)
+		})
+	}
+}
+
+func genPodWithConfigMapVolume(podName, podNamespace, configName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Labels:    map[string]string{redeployment.RedeployLabel: "true"},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: configName,
+					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configName,
+						},
+					},
+					},
+				},
+			},
+		},
+	}
+}
+
+func genPodWithConfigRef(podName, podNamespace, configName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Labels:    map[string]string{redeployment.RedeployLabel: "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: configName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/controllers/redeploy_secret_controller.go
+++ b/controllers/redeploy_secret_controller.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/pluralsh/plural-operator/services/redeployment"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// RedeploySecretReconciler reconciles a Secret object for specified applications
+type RedeploySecretReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the SecretSync object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcile
+func (r *RedeploySecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("secret", req.NamespacedName)
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, secret); err != nil {
+		log.Error(err, "Failed to fetch secret")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	svc, err := redeployment.NewService(redeployment.ResourceSecret, r.Client, secret)
+	if err != nil {
+		log.Error(nil, "could not create Secret service")
+		return reconcile.Result{}, err
+	}
+
+	if !svc.IsControlled() {
+		return reconcile.Result{}, nil
+	}
+
+	if !svc.HasAnnotation() {
+		log.Info("updating secret with new sha")
+		return reconcile.Result{}, svc.UpdateAnnotation()
+	}
+
+	if svc.ShouldDeletePods() {
+		log.Info("deleting Pods")
+		err = svc.DeletePods()
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not delete pods: %w", err)
+		}
+
+		err = svc.UpdateAnnotation()
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update annotation: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RedeploySecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		Complete(r)
+}

--- a/controllers/redeploy_secret_controller.go
+++ b/controllers/redeploy_secret_controller.go
@@ -60,13 +60,13 @@ func (r *RedeploySecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, err
 	}
 
-	if !svc.IsControlled() {
-		return reconcile.Result{}, nil
+	if !svc.HasAnnotation() {
+		log.Info("update secret annotation")
+		return reconcile.Result{}, svc.UpdateAnnotation()
 	}
 
-	if !svc.HasAnnotation() {
-		log.Info("updating secret with new sha")
-		return reconcile.Result{}, svc.UpdateAnnotation()
+	if !svc.IsControlled() {
+		return reconcile.Result{}, nil
 	}
 
 	if svc.ShouldDeletePods() {

--- a/controllers/redeploy_secret_controller_test.go
+++ b/controllers/redeploy_secret_controller_test.go
@@ -1,0 +1,186 @@
+package controllers
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/pluralsh/plural-operator/api/platform/v1alpha1"
+	"github.com/pluralsh/plural-operator/services/redeployment"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+}
+
+func TestReconcileSecret(t *testing.T) {
+	tests := []struct {
+		name                  string
+		secretName            string
+		secretNamespace       string
+		expectedPods          []string
+		existingObjects       []ctrlruntimeclient.Object
+		expectedSHAAnnotation bool
+	}{
+		{
+			name:            "scenario 1: no matching pods, don't add SHA annotation",
+			secretNamespace: "test",
+			secretName:      "testsecret",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testsecret",
+						Namespace: "test",
+					},
+					Data: map[string][]byte{"z": {1, 2, 3}, "a": {4, 5, 6}},
+				},
+				genPodWithSecretVolume("pod1", "test", "somesecret"),
+			},
+			expectedPods: []string{"pod1"},
+		},
+		{
+			name:            "scenario 2: two matching pods, delete those pods",
+			secretNamespace: "test",
+			secretName:      "testsecret",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testsecret",
+						Namespace:   "test",
+						Annotations: map[string]string{redeployment.ShaAnnotation: "xyz"},
+					},
+					Data: map[string][]byte{"z": {1, 2, 3}, "a": {4, 5, 6}},
+				},
+				genPodWithSecretVolume("pod1", "test", "somesecret"),
+				genPodWithSecretVolume("pod2", "test", "testsecret"),
+				genPodWithSecretVolume("pod3", "test", "somesecret"),
+				genPodWithSecretVolume("pod4", "test", "testsecret"),
+			},
+			expectedPods: []string{"pod1", "pod3"},
+		},
+		{
+			name:            "scenario 3: delete pods with secret reference and volumes",
+			secretNamespace: "test",
+			secretName:      "testsecret",
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testsecret",
+						Namespace:   "test",
+						Annotations: map[string]string{redeployment.ShaAnnotation: "xyz"},
+					},
+					Data: map[string][]byte{"z": {1, 2, 3}, "a": {4, 5, 6}},
+				},
+				genPodWithSecretVolume("pod1", "test", "somesecret"),
+				genPodWithSecretVolume("pod2", "test", "testsecret"),
+				genPodWithSecretVolume("pod3", "test", "somesecret"),
+				genPodWithSecretVolume("pod4", "test", "testsecret"),
+				genPodWithSecretRef("pod5", "test", "testsecret"),
+				genPodWithSecretRef("pod6", "test", "somesecret"),
+			},
+			expectedPods: []string{"pod1", "pod3", "pod6"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			fakeClient := fake.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(test.existingObjects...).
+				Build()
+
+			// act
+			ctx := context.Background()
+			target := RedeploySecretReconciler{
+				Client: fakeClient,
+				Log:    ctrl.Log.WithName("controllers").WithName("RedeploySecretsController"),
+				Scheme: scheme.Scheme,
+			}
+
+			_, err := target.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: test.secretName, Namespace: test.secretNamespace}})
+			assert.NoError(t, err)
+
+			secret := &corev1.Secret{}
+			err = fakeClient.Get(ctx, client.ObjectKey{Name: test.secretName, Namespace: test.secretNamespace}, secret)
+			assert.NoError(t, err)
+
+			if test.expectedSHAAnnotation {
+				_, shaAnnotation := secret.Annotations[redeployment.ShaAnnotation]
+				assert.True(t, shaAnnotation, "expected SHA annotation")
+			}
+
+			existingPods := &corev1.PodList{}
+			labelSelector, err := redeployment.RedeployLabelSelector()
+			assert.NoError(t, err)
+			err = fakeClient.List(ctx, existingPods, &client.ListOptions{Namespace: test.secretNamespace, LabelSelector: labelSelector})
+			assert.NoError(t, err)
+			existingPodNames := []string{}
+			for _, pod := range existingPods.Items {
+				existingPodNames = append(existingPodNames, pod.Name)
+			}
+			sort.Strings(existingPodNames)
+			sort.Strings(test.expectedPods)
+
+			assert.Equal(t, existingPodNames, test.expectedPods)
+		})
+	}
+}
+
+func genPodWithSecretVolume(podName, podNamespace, secretName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Labels:    map[string]string{redeployment.RedeployLabel: "true"},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: secretName,
+					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+						SecretName: secretName,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func genPodWithSecretRef(podName, podNamespace, secretName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Labels:    map[string]string{redeployment.RedeployLabel: "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							SecretRef: &corev1.SecretEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/controllers/redeploy_secret_controller_test.go
+++ b/controllers/redeploy_secret_controller_test.go
@@ -1,3 +1,22 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/controllers/redeploy_secret_controller_test.go
+++ b/controllers/redeploy_secret_controller_test.go
@@ -54,7 +54,7 @@ func TestReconcileSecret(t *testing.T) {
 		expectedSHAAnnotation bool
 	}{
 		{
-			name:            "scenario 1: no matching pods, don't add SHA annotation",
+			name:            "scenario 1: no matching pods",
 			secretNamespace: "test",
 			secretName:      "testsecret",
 			existingObjects: []ctrlruntimeclient.Object{
@@ -67,6 +67,7 @@ func TestReconcileSecret(t *testing.T) {
 				},
 				genPodWithSecretVolume("pod1", "test", "somesecret"),
 			},
+
 			expectedPods: []string{"pod1"},
 		},
 		{
@@ -137,10 +138,8 @@ func TestReconcileSecret(t *testing.T) {
 			err = fakeClient.Get(ctx, client.ObjectKey{Name: test.secretName, Namespace: test.secretNamespace}, secret)
 			assert.NoError(t, err)
 
-			if test.expectedSHAAnnotation {
-				_, shaAnnotation := secret.Annotations[redeployment.ShaAnnotation]
-				assert.True(t, shaAnnotation, "expected SHA annotation")
-			}
+			_, shaAnnotation := secret.Annotations[redeployment.ShaAnnotation]
+			assert.True(t, shaAnnotation, "expected SHA annotation")
 
 			existingPods := &corev1.PodList{}
 			labelSelector, err := redeployment.RedeployLabelSelector()
@@ -154,7 +153,7 @@ func TestReconcileSecret(t *testing.T) {
 			sort.Strings(existingPodNames)
 			sort.Strings(test.expectedPods)
 
-			assert.Equal(t, existingPodNames, test.expectedPods)
+			assert.Equal(t, test.expectedPods, existingPodNames)
 		})
 	}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,3 +1,6 @@
+//go:build suit
+// +build suit
+
 /*
 Copyright 2021.
 

--- a/main.go
+++ b/main.go
@@ -171,6 +171,24 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "License")
 		os.Exit(1)
 	}
+
+	if err = (&controllers.ConfigMapRedeployReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("ConfigMapRedeploy"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ConfigMapRedeploy")
+		os.Exit(1)
+	}
+	if err = (&controllers.RedeploySecretReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("SecretRedeploy"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SecretRedeploy")
+		os.Exit(1)
+	}
+
 	// //+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/services/redeployment/service_configmap.go
+++ b/services/redeployment/service_configmap.go
@@ -1,0 +1,123 @@
+package redeployment
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type configMapService struct {
+	client    ctrclient.Client
+	configMap *corev1.ConfigMap
+	ctx       context.Context
+
+	pods         []corev1.Pod
+	matchingPods map[string]corev1.Pod
+}
+
+// IsControlled implements Service.IsControlled interface.
+func (c *configMapService) IsControlled() bool {
+	controlled := false
+	for _, pod := range c.pods {
+		for _, volume := range pod.Spec.Volumes {
+			if isUsed(volume, ResourceConfigMap, c.configMap.Name) {
+				controlled = true
+				c.matchingPods[pod.Name] = pod
+			}
+		}
+		for _, container := range pod.Spec.Containers {
+			for _, secretRef := range container.EnvFrom {
+				if isUsedReferance(secretRef, ResourceConfigMap, c.configMap.Name) {
+					controlled = true
+					c.matchingPods[pod.Name] = pod
+				}
+			}
+		}
+	}
+
+	return controlled
+}
+
+// HasAnnotation implements Service.HasAnnotation interface.
+func (c *configMapService) HasAnnotation() bool {
+	_, exists := c.configMap.Annotations[ShaAnnotation]
+	return exists
+}
+
+// UpdateAnnotation implements Service.UpdateAnnotation interface.
+func (c *configMapService) UpdateAnnotation() error {
+	sha := c.getSHA()
+	c.configMap.Annotations[ShaAnnotation] = sha
+
+	return c.client.Update(c.ctx, c.configMap)
+}
+
+// ShouldDeletePods implements Service.ShouldDeletePods interface.
+func (c *configMapService) ShouldDeletePods() bool {
+	existingSHA := c.configMap.Annotations[ShaAnnotation]
+	expectedSHA := c.getSHA()
+
+	return existingSHA != expectedSHA
+}
+
+// DeletePods implements Service.DeletePods interface.
+func (c *configMapService) DeletePods() error {
+	for _, pod := range c.matchingPods {
+		if err := c.client.Delete(c.ctx, &pod); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getSHA implements Service.getSHA interface.
+func (c *configMapService) getSHA() string {
+	sha := sha256.New()
+	dataKeys := make([]string, 0)
+	binaryDataKeys := make([]string, 0)
+
+	for key := range c.configMap.Data {
+		dataKeys = append(dataKeys, key)
+	}
+
+	for key := range c.configMap.BinaryData {
+		binaryDataKeys = append(binaryDataKeys, key)
+	}
+
+	sort.Strings(dataKeys)
+	sort.Strings(binaryDataKeys)
+
+	for _, key := range dataKeys {
+		sha.Write([]byte(c.configMap.Data[key]))
+	}
+
+	for _, key := range binaryDataKeys {
+		sha.Write(c.configMap.BinaryData[key])
+	}
+
+	return hex.EncodeToString(sha.Sum(nil))
+}
+
+func newConfigMapService(client ctrclient.Client, configMap *corev1.ConfigMap) (Service, error) {
+	if configMap.Annotations == nil {
+		configMap.Annotations = map[string]string{}
+	}
+	ctx := context.Background()
+	pods := &corev1.PodList{}
+
+	labelSelector, err := RedeployLabelSelector()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.List(ctx, pods, &ctrclient.ListOptions{Namespace: configMap.Namespace, LabelSelector: labelSelector}); err != nil {
+		return nil, err
+	}
+
+	return &configMapService{client: client, configMap: configMap, ctx: ctx, pods: pods.Items, matchingPods: map[string]corev1.Pod{}}, nil
+}

--- a/services/redeployment/service_factory.go
+++ b/services/redeployment/service_factory.go
@@ -1,0 +1,21 @@
+package redeployment
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewService(resource Resource, client client.Client, object client.Object) (Service, error) {
+	switch resource {
+	case ResourceConfigMap:
+		configMap := object.(*corev1.ConfigMap)
+		return newConfigMapService(client, configMap)
+	case ResourceSecret:
+		secret := object.(*corev1.Secret)
+		return newSecretService(client, secret)
+	}
+
+	panic(fmt.Sprintf("unsupported resource found: %s", resource))
+}

--- a/services/redeployment/service_secret.go
+++ b/services/redeployment/service_secret.go
@@ -1,0 +1,111 @@
+package redeployment
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type secretService struct {
+	client ctrclient.Client
+	secret *corev1.Secret
+	ctx    context.Context
+
+	pods         []corev1.Pod
+	matchingPods map[string]corev1.Pod
+}
+
+func (s *secretService) IsControlled() bool {
+	controlled := false
+	for _, pod := range s.pods {
+		for _, volume := range pod.Spec.Volumes {
+			if isUsed(volume, ResourceSecret, s.secret.Name) {
+				controlled = true
+				s.matchingPods[pod.Name] = pod
+			}
+		}
+		for _, container := range pod.Spec.Containers {
+			for _, secretRef := range container.EnvFrom {
+				if isUsedReferance(secretRef, ResourceSecret, s.secret.Name) {
+					controlled = true
+					s.matchingPods[pod.Name] = pod
+				}
+			}
+		}
+	}
+
+	return controlled
+}
+
+func (s *secretService) HasAnnotation() bool {
+	_, ok := s.secret.Annotations[ShaAnnotation]
+	return ok
+}
+
+func (s *secretService) UpdateAnnotation() error {
+	sha := s.getSHA()
+	s.secret.Annotations[ShaAnnotation] = sha
+
+	return s.client.Update(s.ctx, s.secret)
+}
+
+func (s *secretService) ShouldDeletePods() bool {
+	existingSHA := s.secret.Annotations[ShaAnnotation]
+	expectedSHA := s.getSHA()
+
+	return existingSHA != expectedSHA
+}
+
+func (s *secretService) DeletePods() error {
+	for _, pod := range s.matchingPods {
+		if err := s.client.Delete(s.ctx, &pod); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *secretService) getSHA() string {
+	sha := sha256.New()
+	dataKeys := make([]string, 0)
+
+	for key := range s.secret.Data {
+		dataKeys = append(dataKeys, key)
+	}
+
+	sort.Strings(dataKeys)
+
+	for _, key := range dataKeys {
+		sha.Write(s.secret.Data[key])
+	}
+
+	return hex.EncodeToString(sha.Sum(nil))
+}
+
+func newSecretService(client ctrclient.Client, secret *corev1.Secret) (Service, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("the secret can not be nil")
+	}
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	ctx := context.Background()
+	pods := &corev1.PodList{}
+
+	labelSelector, err := RedeployLabelSelector()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.List(ctx, pods, &ctrclient.ListOptions{Namespace: secret.Namespace, LabelSelector: labelSelector}); err != nil {
+		return nil, err
+	}
+
+	return &secretService{client: client, secret: secret, ctx: ctx, pods: pods.Items, matchingPods: map[string]corev1.Pod{}}, nil
+}

--- a/services/redeployment/types.go
+++ b/services/redeployment/types.go
@@ -1,0 +1,46 @@
+package redeployment
+
+type Resource string
+
+const (
+	ResourceConfigMap = "configmap"
+	ResourceSecret    = "secret"
+)
+
+// Annotations used by the redeployment operator
+const (
+	RedeployLabel = "platform.plural.sh/redeploy"
+	ShaAnnotation = "platform.plural.sh/sha"
+)
+
+// Service is a redeployment operator service that simplifies the process of
+// finding the application that uses a Resource and triggering a rollout restart
+// of the application in order to be able to always use the latest config values
+// without having to manually restart the application after every change.
+//
+// Currently supported resources:
+//   - ResourceConfigMap
+//   - ResourceSecret
+type Service interface {
+	// IsControlled checks if the v1alpha1.Redeployment Resource should be controlled by the
+	// redeployment operator.
+	IsControlled() bool
+
+	// HasAnnotation checks if controlled Resource contains SHA annotation.
+	HasAnnotation() bool
+
+	// UpdateAnnotation updates the SHA annotation with the latest SHA
+	// calculated based on the Resource data. It is used to determine
+	// if a Resource has been updated.
+	UpdateAnnotation() error
+
+	// ShouldDeletePods checks if existing SHA annotation is in sync with the actual SHA
+	// calculated based on the latest Resource data.
+	ShouldDeletePods() bool
+
+	// DeletePods deletes all matching pods
+	DeletePods() error
+
+	// getSHA calculates the SHA of the Resource data.
+	getSHA() string
+}

--- a/services/redeployment/utils.go
+++ b/services/redeployment/utils.go
@@ -1,0 +1,39 @@
+package redeployment
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+func isUsed(volume corev1.Volume, resource Resource, name string) bool {
+	switch resource {
+	case ResourceConfigMap:
+		return volume.ConfigMap != nil && volume.ConfigMap.Name == name
+	case ResourceSecret:
+		return volume.Secret != nil && volume.Secret.SecretName == name
+	}
+
+	return false
+}
+
+func isUsedReferance(envFromSource corev1.EnvFromSource, resource Resource, name string) bool {
+	switch resource {
+	case ResourceConfigMap:
+		return envFromSource.ConfigMapRef != nil && envFromSource.ConfigMapRef.Name == name
+	case ResourceSecret:
+		return envFromSource.SecretRef != nil && envFromSource.SecretRef.Name == name
+	}
+
+	return false
+}
+
+func RedeployLabelSelector() (labels.Selector, error) {
+	req, err := labels.NewRequirement(RedeployLabel, selection.Equals, []string{"true"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build label selector: %w", err)
+	}
+	return labels.Parse(req.String())
+}

--- a/test/redeployment/01_namespace.yaml
+++ b/test/redeployment/01_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-app

--- a/test/redeployment/02_configmap.yaml
+++ b/test/redeployment/02_configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-app-config
+  namespace: demo-app
+data:
+  # property-like keys; each key maps to a simple value
+  player_initial_lives: "3"
+  ui_properties_file_name: "user-interface.properties"
+
+  # file-like keys
+  game.properties: |
+    enemy.types=aliens,monsters
+    player.maximum-lives=5
+  user-interface.properties: |
+    color.good=purple
+    color.bad=yellow
+    allow.textmode=true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-app-secret
+  namespace: demo-app
+data:
+  password: TXEyRCMoOGdmMDk=
+  username: cm9vdA==

--- a/test/redeployment/03_pod.yaml
+++ b/test/redeployment/03_pod.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: demo-app
+  labels:
+    platform.plural.sh/redeploy: "true"
+spec:
+  volumes:
+    - name: config
+      configMap:
+        # Provide the name of the ConfigMap you want to mount.
+        name: demo-app-config
+        # An array of keys from the ConfigMap to create as files
+        items:
+          - key: "game.properties"
+            path: "game.properties"
+          - key: "user-interface.properties"
+            path: "user-interface.properties"
+  containers:
+    - name: test-container
+      image: alpine
+      command: ["sleep", "3600"]
+      env:
+        - name: PLAYER_INITIAL_LIVES # Notice that the case is different here
+          # from the key name in the ConfigMap.
+          valueFrom:
+            configMapKeyRef:
+              name: demo-app-config     # The ConfigMap this value comes from.
+              key: player_initial_lives # The key to fetch.
+        - name: UI_PROPERTIES_FILE_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: demo-app-config
+              key: ui_properties_file_name
+      envFrom:
+        - secretRef:
+            name: demo-app-secret
+      volumeMounts:
+        - name: config
+          mountPath: "/config"
+  restartPolicy: Never


### PR DESCRIPTION
This PR implements two controllers to watch secret and configMap changes. If something has changed then all pods which use them are deleted. The pod must have a special label added by OAuthInjector.