### PR TITLE
ENG-558 add pod sweeper controller

### DIFF
--- a/controllers/pod_sweeper_controller.go
+++ b/controllers/pod_sweeper_controller.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Now stubbed out to allow testing.
+var Now = time.Now
+
+const defaultSweepAfter = 2 * time.Hour
+
+// PodSweeperReconciler reconciles a Pod object
+type PodSweeperReconciler struct {
+	client.Client
+	Log         logr.Logger
+	Scheme      *runtime.Scheme
+	DeleteAfter time.Duration
+}
+
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the SecretSync object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcilee
+func (r *PodSweeperReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("pod", req.NamespacedName)
+
+	if r.DeleteAfter == 0 {
+		r.DeleteAfter = defaultSweepAfter
+	}
+
+	var pod corev1.Pod
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Get a standalone pod
+	// Skip all k8s workflow pods. The owner reference for the workflow pod is always set with the specific kind: ReplicaSet, DaemonSet
+	if pod.OwnerReferences != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Skip running pods, and check them later
+	if pod.Status.Phase == corev1.PodRunning {
+		return ctrl.Result{
+			RequeueAfter: r.DeleteAfter,
+		}, nil
+	}
+
+	// If the condition is not set yet then set lastNotReadyTimestamp to Now() to enforce the check for later
+	now := Now()
+	lastNotReadyTimestamp := metav1.Time{now}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			lastNotReadyTimestamp = condition.LastTransitionTime
+		}
+	}
+
+	notReadyDuration := now.Sub(lastNotReadyTimestamp.Time)
+	checkDuration := r.DeleteAfter
+	if notReadyDuration >= checkDuration {
+		if err := r.Delete(ctx, &pod); err != nil {
+			log.Error(err, "Failed to delete pod")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	repeatAfter := checkDuration.Truncate(notReadyDuration)
+	return ctrl.Result{RequeueAfter: repeatAfter + time.Minute}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PodSweeperReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	mgr.GetControllerOptions()
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		Complete(r)
+}

--- a/controllers/pod_sweeper_controller_test.go
+++ b/controllers/pod_sweeper_controller_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileSweeper(t *testing.T) {
+	tests := []struct {
+		name            string
+		podName         string
+		podNamespace    string
+		expectedError   string
+		expectedResult  ctrl.Result
+		shouldDeletePod bool
+		existingObjects []ctrlruntimeclient.Object
+	}{
+		{
+			name:            "scenario 1: check and delete pod",
+			podNamespace:    "test",
+			podName:         "test",
+			shouldDeletePod: true,
+			expectedResult:  ctrl.Result{},
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: corev1.PodSpec{},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(Now().Add(-10 * time.Minute))},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:            "scenario 2: pod is pending, check later",
+			podNamespace:    "test",
+			podName:         "test",
+			shouldDeletePod: true,
+			expectedResult:  ctrl.Result{RequeueAfter: 6 * time.Minute},
+			existingObjects: []ctrlruntimeclient.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: corev1.PodSpec{},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			fakeClient := fake.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(test.existingObjects...).
+				Build()
+
+			// act
+			ctx := context.Background()
+			target := PodSweeperReconciler{
+				Client:      fakeClient,
+				Log:         ctrl.Log.WithName("controllers").WithName("PodSweeperController"),
+				Scheme:      scheme.Scheme,
+				DeleteAfter: 5 * time.Minute,
+			}
+
+			result, err := target.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: test.podName, Namespace: test.podNamespace}})
+			if test.expectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, err.Error(), test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				err := fakeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: test.podNamespace, Name: test.name}, &corev1.Pod{})
+				if test.shouldDeletePod {
+					err = ctrlruntimeclient.IgnoreNotFound(err)
+				}
+				assert.NoError(t, err)
+				assert.Equal(t, result, test.expectedResult)
+			}
+
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -198,6 +198,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.PodSweeperReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("PodSweeperController"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "PodSweeperController")
+		os.Exit(1)
+	}
 	// //+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
## Summary
Add pod sweeper controller. Checks standalone pod's status and if they are not ready for desired time then deletes them.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.