### PR TITLE
add friendly names to the wireguard config for the exporter

### DIFF
--- a/config/samples/vpn_v1alpha1_wireguardserver.yaml
+++ b/config/samples/vpn_v1alpha1_wireguardserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   serviceType: LoadBalancer
-  wireguardImage: dkr.plural.sh/bootstrap/wireguard-server:0.1.1
+  wireguardImage: dkr.plural.sh/bootstrap/wireguard-server:0.1.2
   networkCIDR: 10.8.0.1/24
   mtu: "8921"
   dns:

--- a/controllers/vpn/wireguardserver_controller.go
+++ b/controllers/vpn/wireguardserver_controller.go
@@ -195,7 +195,7 @@ ListenPort = %v
 				continue
 			}
 
-			peerConfig = peerConfig + fmt.Sprintf("\n[Peer]\nPublicKey = %s\nallowedIps = %s\n\n", peer.Spec.PublicKey, peer.Spec.Address)
+			peerConfig = peerConfig + fmt.Sprintf("\n[Peer]\n# friendly_name = %s\nPublicKey = %s\nallowedIps = %s\n\n", peer.Name, peer.Spec.PublicKey, peer.Spec.Address)
 		}
 
 		wgConfig = wgConfig + peerConfig

--- a/hack/images/wireguard/entrypoint.sh
+++ b/hack/images/wireguard/entrypoint.sh
@@ -28,7 +28,7 @@ function watch_and_update() {
   trap 'shutdown_wg "$1"' SIGTERM SIGINT SIGQUIT
   cp /tmp/wireguard/config /etc/wireguard/wg0.conf
   wg-quick up wg0
-  /usr/local/bin/prometheus_wireguard_exporter &>/dev/null &
+  /usr/local/bin/prometheus_wireguard_exporter -n /etc/wireguard/wg0.conf &>/dev/null &
   fswatch -o /tmp/wireguard/ | (while read; do update_config; done)
 }
 

--- a/hack/images/wireguard/release.sh
+++ b/hack/images/wireguard/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY="${REPOSITORY:-dkr.plural.sh/bootstrap/wireguard-server}"
-VERSION=0.1.1
+VERSION=0.1.2
 SUFFIX=""
 
 docker buildx build --platform linux/amd64 --no-cache --pull --push -f "Dockerfile" -t "${REPOSITORY}:${VERSION}${SUFFIX}" .


### PR DESCRIPTION
## Summary
Adds a comment with the friendly name of wireguard peers that the prometheus exporter uses to make it easier for people to identify traffic from certain devices.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.